### PR TITLE
Configurable filetypes

### DIFF
--- a/plugin/indentobject.vim
+++ b/plugin/indentobject.vim
@@ -20,7 +20,7 @@ vnoremap <silent>ai :<C-u>call IndentTextObject(0)<CR><Esc>gv
 vnoremap <silent>ii :<C-u>call IndentTextObject(1)<CR><Esc>gv
 
 if !exists("g:indentobject_meaningful_indentation")
-  let g:indentobject_meaningful_indentation = ["haml", "sass", "python"]
+  let g:indentobject_meaningful_indentation = ["haml", "sass", "python", "yaml"]
 end
 
 function! IndentTextObject(inner)

--- a/plugin/indentobject.vim
+++ b/plugin/indentobject.vim
@@ -19,8 +19,12 @@ onoremap <silent>ii :<C-u>call IndentTextObject(1)<CR>
 vnoremap <silent>ai :<C-u>call IndentTextObject(0)<CR><Esc>gv
 vnoremap <silent>ii :<C-u>call IndentTextObject(1)<CR><Esc>gv
 
+if !exists("g:indentobject_meaningful_indentation")
+  let g:indentobject_meaningful_indentation = ["haml", "sass", "python"]
+end
+
 function! IndentTextObject(inner)
-  if &filetype == 'haml' || &filetype == 'sass' || &filetype == 'python'
+  if index(g:indentobject_meaningful_indentation, &filetype) >= 0
     let meaningful_indentation = 1
   else
     let meaningful_indentation = 0


### PR DESCRIPTION
Hey, Austin!

Thanks for pulling out this plugin; I'm loving it.

I noticed the other day that `vai` didn't do the right thing in a yaml file -- "yaml" isn't among the triggering filetypes for meaningful indentation but should be.

Would you consider this patch to make those filetypes configurable? (And I think I'll push a second commit to include "yaml" in the default configuration.)

All the best,  -- Matthew
